### PR TITLE
Undo edit or delete Todo actions

### DIFF
--- a/src/app/components/todo-list/todo-item/todo-item.component.ts
+++ b/src/app/components/todo-list/todo-item/todo-item.component.ts
@@ -42,15 +42,9 @@ export class TodoItemComponent {
   submitEdit(): void {
     this.isEditing = false;
     this.edit.emit(this.oldTodo);
-    this.alertNotify('Edited todo');
   }
 
   handleRemoveClick(): void {
     this.remove.emit(this.todo.id);
-    this.alertNotify('Removed todo');
-  }
-
-  alertNotify(message: string, duration = 2000): void {
-    this.notificationService.open(message, duration);
   }
 }

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -7,9 +7,24 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 export class NotificationService {
   constructor(public snackBar: MatSnackBar, private zone: NgZone) {}
 
-  public open(message: string, duration = 20000, action = 'Got it'): void {
+  public alert(message: string, duration = 10000, action = 'Got it'): void {
     this.zone.run(() => {
       this.snackBar.open(message, action, { duration });
+    });
+  }
+
+  public undoAlert(
+    mode: { undo: boolean },
+    revertCallback: Function,
+    message: string,
+    duration = 3000,
+    action = 'Undo'
+  ): void {
+    this.zone.run(() => {
+      this.snackBar
+        .open(message, action, { duration })
+        .onAction()
+        .subscribe(() => revertCallback());
     });
   }
 }


### PR DESCRIPTION
Allows users to revert changes after **Editing** or **Deleting** a Todo by clicking "Undo" in a pop-up window